### PR TITLE
Updating node-inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,15 +14,16 @@
       "url": "http://github.com/akamensky/"
     }
   ],
-  "keywords": ["monitor", 
-    "development", 
-    "restart", 
-    "autoload", 
-    "reload", 
-    "debug", 
-    "node-inspector", 
-    "dev", 
-    "inspector", 
+  "keywords": [
+    "monitor",
+    "development",
+    "restart",
+    "autoload",
+    "reload",
+    "debug",
+    "node-inspector",
+    "dev",
+    "inspector",
     "console"
   ],
   "repository": {
@@ -36,15 +37,17 @@
     "nodev": "./nodev.js"
   },
   "dependencies": {
-    "nodemon": "1.3.7",
-    "node-inspector": "0.9.1",
-    "portscanner": "1.0.0",
-    "async":"0.9.0"
+    "async": "^0.9.0",
+    "node-inspector": "^0.12.7",
+    "nodemon": "^1.3.7",
+    "portscanner": "^1.0.0"
   },
   "preferGlobal": true,
-  "licenses": [{
-    "type": "MIT",
-    "url": "http://rem.mit-license.org"
-  }],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://rem.mit-license.org"
+    }
+  ],
   "main": "./nodev"
 }


### PR DESCRIPTION
I was having issues installing v8-debug.  Updating node-inspector updates v8-debug to a much more recent version which works.
